### PR TITLE
Develop

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -245,9 +245,6 @@ class ToxiproxyClient extends EventTarget {
         timeout: [
             { name: 'timeout', type: 'number', default: 10000, label: 'Timeout (ms)' }
         ],
-        reset_peer: [
-            { name: 'timeout', type: 'number', default: 0, label: 'Timeout (ms)' }
-        ],
         slicer: [
             { name: 'average_size', type: 'number', default: 64, label: 'Average Size (bytes)' },
             { name: 'size_variation', type: 'number', default: 32, label: 'Size Variation (bytes)' },

--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,6 @@
                                     <option value="bandwidth" class="bg-gray-900">BANDWIDTH</option>
                                     <option value="slow_close" class="bg-gray-900">SLOW_CLOSE</option>
                                     <option value="timeout" class="bg-gray-900">TIMEOUT</option>
-                                    <option value="reset_peer" class="bg-gray-900">RESET_PEER</option>
                                     <option value="slicer" class="bg-gray-900">SLICER</option>
                                     <option value="limit_data" class="bg-gray-900">LIMIT_DATA</option>
                                 </select>

--- a/src/routes/schemas/toxic.js
+++ b/src/routes/schemas/toxic.js
@@ -16,6 +16,7 @@ export default {
         'corrupt',
         'delay',
         'echo',
+        'reset_peer',
       ],
     },
     name: {

--- a/src/routes/schemas/toxic.js
+++ b/src/routes/schemas/toxic.js
@@ -15,8 +15,7 @@ export default {
         'reset',
         'corrupt',
         'delay',
-        'echo',
-        'reset_peer',
+        'echo'
       ],
     },
     name: {


### PR DESCRIPTION
This pull request removes support for the `reset_peer` toxic and makes minor adjustments to the `toxic.js` schema. The most important changes are grouped below:

### Removal of `reset_peer` toxic:
* [`public/client.js`](diffhunk://#diff-3c1c78fbccf841ecda30fc632b85abd36bd1a172918d5cad21fcbfea3f74a321L248-L250): Removed the `reset_peer` toxic configuration from the `ToxiproxyClient` class.
* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL128): Deleted the `reset_peer` option from the dropdown menu in the HTML interface.

### Schema adjustments:
* [`src/routes/schemas/toxic.js`](diffhunk://#diff-646f4ed686810235678db9309c6350e73dfc387807b49cb8a31fdf24ed0ec28eL18-R18): Fixed a trailing comma issue in the `toxic.js` schema.